### PR TITLE
#3179 AudioKitのXcode12.2対応

### DIFF
--- a/AudioKit/Common/Internals/Utilities/Circular Buffer/TPCircularBuffer+AudioBufferList.h
+++ b/AudioKit/Common/Internals/Utilities/Circular Buffer/TPCircularBuffer+AudioBufferList.h
@@ -29,7 +29,7 @@
 
 
 #ifdef __cplusplus
-extern "C++" {
+extern "C" {
 #endif
 
 #include "TPCircularBuffer.h"


### PR DESCRIPTION
## 概要
d-o-n-u-t-s/mixch-doc#3179

## 動作確認方法
- 動作確認するために分かりにくい手順などあればここに書いておく

## やったこと
- 関数がミクチャ側から参照できないため、externをcに戻した
- 修正前後でUI変更があった場合はスクショも貼る

|before|after|
|------|-----|
|||

## 動作確認端末
- [ ] 【SYS1015】iPhone11 Pro Max 13.6 (2ファクタ可能)
- [ ] 【SYS1006】iPhone11 14.0 (2ファクタ可能)
- [ ] 【SYS1000】iPhone8 12.4
- [ ] 【SYS961】iPhoneXR 12.4
- [ ] 【SYS886】iPhoneXs Max 12.1.2
- [ ] 【SYS834】iPhoneX 13.4.1
- [ ] 【SYS828】iPhoneX 11.2.6
- [ ] 【SYS792】iPhone6 12.4.4
- [ ] 【SYS670】iPhone7 Plus 11.2.1 (2ファクタ可能)
- [ ] 【SYS653】iPhone7 13.2.3 (2ファクタ可能)
- [ ] 【SYS451】iPhone5s 11.4.1
- [ ] 【SYS427】iPhone6 12.4
- [ ] 【SYS410】iPhone5s 11.4.1
- [ ] 【SYS377】iPhone6s Plus 13.2.3
- [ ] 【SYS160】iPhoneSE 13.3 (2ファクタ可能)
- [ ] 【SYS153】iPhone6 Plus 12.4.3

## テスト
こちらでテスト
https://github.com/d-o-n-u-t-s/mixch-ios/pull/1748

### テスト観点
- テキスト関連
   - 絵文字を入力
   - 文字数が多い場合
- ネットワーク関連
   - オフライン状態
   - 通信状態が悪い
- UI
   - ノッチあり・なし
   - ディスプレイサイズの違い
   - jやqなどでdesentが文字切れしていないか
   - タブバーに埋もれていないか
   - 画面回転
- OS
   - OSの違い
